### PR TITLE
Add Range function to cache implementations

### DIFF
--- a/src/LRU.go
+++ b/src/LRU.go
@@ -110,3 +110,13 @@ func (lru *lruCache) Get(key Key) (value Value, err error) {
 	lru.Put(key, value)
 	return
 }
+
+// Range iterates over each entry in the cache. Iteration stops if f returns
+// false.
+func (lru *lruCache) Range(f func(Key, Value) bool) {
+	for k, node := range lru.store {
+		if !f(k, node.value) {
+			return
+		}
+	}
+}

--- a/src/LRU_test.go
+++ b/src/LRU_test.go
@@ -1,12 +1,17 @@
-package caches
+package caches_test
 
 import (
+	"context"
 	"testing"
+
 	"github.com/stretchr/testify/assert"
+
+	caches "github.com/npxcomplete/caches/src"
+	thread_safe "github.com/npxcomplete/caches/src/thread_safe"
 )
 
 func Test_AddToEmptyCache(t *testing.T) {
-	var kvLRU Interface = NewLRUCache(2)
+	var kvLRU caches.Interface = caches.NewLRUCache(2)
 
 	kvLRU.Put(5, "hello")
 
@@ -19,7 +24,7 @@ func Test_AddToEmptyCache(t *testing.T) {
 }
 
 func Test_AddToFullCache(t *testing.T) {
-	var kvLRU Interface = NewLRUCache(2)
+	var kvLRU caches.Interface = caches.NewLRUCache(2)
 
 	kvLRU.Put(5, "hello")
 	kvLRU.Put(6, "world")
@@ -41,7 +46,7 @@ func Test_AddToFullCache(t *testing.T) {
 }
 
 func Test_QueriedValuesReset(t *testing.T) {
-	var kvLRU Interface = NewLRUCache(2)
+	var kvLRU caches.Interface = caches.NewLRUCache(2)
 
 	kvLRU.Put(5, "hello")
 	kvLRU.Put(6, "world")
@@ -65,7 +70,7 @@ func Test_QueriedValuesReset(t *testing.T) {
 }
 
 func Test_ValueNeverPresent(t *testing.T) {
-	var kvLRU Interface = NewLRUCache(2)
+	var kvLRU caches.Interface = caches.NewLRUCache(2)
 
 	kvLRU.Put(5, "hello")
 	kvLRU.Put(6, "world")
@@ -74,4 +79,62 @@ func Test_ValueNeverPresent(t *testing.T) {
 
 	_, err = kvLRU.Get(12)
 	assert.NotNil(t, err)
+}
+
+func Test_RangeVisitsAll(t *testing.T) {
+	var kvLRU caches.Interface = caches.NewLRUCache(2)
+
+	kvLRU.Put(1, "a")
+	kvLRU.Put(2, "b")
+
+	visited := make(map[int]string)
+	kvLRU.Range(func(k caches.Key, v caches.Value) bool {
+		visited[k.(int)] = v.(string)
+		return true
+	})
+
+	assert.Equal(t, 2, len(visited))
+	assert.Equal(t, "a", visited[1])
+	assert.Equal(t, "b", visited[2])
+}
+
+func Test_RangeEarlyExit(t *testing.T) {
+	var kvLRU caches.Interface = caches.NewLRUCache(3)
+	kvLRU.Put(1, "a")
+	kvLRU.Put(2, "b")
+	kvLRU.Put(3, "c")
+
+	count := 0
+	kvLRU.Range(func(k caches.Key, v caches.Value) bool {
+		count++
+		return false
+	})
+
+	assert.Equal(t, 1, count)
+}
+
+func Test_RangeThreadSafeWrappers(t *testing.T) {
+	cache := caches.NewLRUCache(2)
+	cache.Put(1, "a")
+	cache.Put(2, "b")
+
+	guard := thread_safe.NewGuardedCache(cache)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	band := thread_safe.NewOutOfBandCache(ctx, cache)
+
+	countGuard := 0
+	guard.Range(func(k caches.Key, v caches.Value) bool {
+		countGuard++
+		return true
+	})
+
+	countBand := 0
+	band.Range(func(k caches.Key, v caches.Value) bool {
+		countBand++
+		return true
+	})
+
+	assert.Equal(t, 2, countGuard)
+	assert.Equal(t, 2, countBand)
 }

--- a/src/hashicorp.go
+++ b/src/hashicorp.go
@@ -7,9 +7,10 @@ type hashi2Q struct {
 }
 
 func (h hashi2Q) Keys() []Key {
-	keys := make([]Key, 0 , 8)
-	for _, key := range h.Keys() {
-		keys = append(keys, key)
+	raw := h.inner.Keys()
+	keys := make([]Key, len(raw))
+	for i, k := range raw {
+		keys[i] = k
 	}
 	return keys
 }
@@ -25,6 +26,20 @@ func (h hashi2Q) Get(k Key) (get Value, err error) {
 		err = MissingValueError
 	}
 	return
+}
+
+// Range invokes f for every key/value pair stored in the cache. Iteration
+// stops if f returns false.
+func (h hashi2Q) Range(f func(Key, Value) bool) {
+	for _, k := range h.inner.Keys() {
+		v, ok := h.inner.Peek(k)
+		if !ok {
+			continue
+		}
+		if !f(k, v) {
+			return
+		}
+	}
 }
 
 func New2Q(capacity int) hashi2Q {

--- a/src/templates/LRU_wrapper.go
+++ b/src/templates/LRU_wrapper.go
@@ -34,3 +34,12 @@ func (cache privateGenericKeyGenericValueLRUCache) Get(key GenericKey) (result G
 	result, _ = value.(GenericValue)
 	return
 }
+
+// see caches.Interface for contract
+func (cache privateGenericKeyGenericValueLRUCache) Range(f func(GenericKey, GenericValue) bool) {
+	cache.generic.Range(func(k caches.Key, v caches.Value) bool {
+		key, _ := k.(GenericKey)
+		val, _ := v.(GenericValue)
+		return f(key, val)
+	})
+}

--- a/src/thread_safe/guarded_cache.go
+++ b/src/thread_safe/guarded_cache.go
@@ -13,8 +13,8 @@ func NewGuardedCache(p caches.Interface) caches.Interface {
 }
 
 // genny is case sensitive even though this has other meanings in go, so we prefix the intent.
-type  guardedLRU struct {
-	mut sync.Mutex
+type guardedLRU struct {
+	mut     sync.Mutex
 	generic caches.Interface
 }
 
@@ -33,9 +33,15 @@ func (cache *guardedLRU) Put(key caches.Key, value caches.Value) caches.Value {
 }
 
 // see caches.Interface for contract
-func (cache *guardedLRU)  Get(key caches.Key) (result caches.Value, err error) {
+func (cache *guardedLRU) Get(key caches.Key) (result caches.Value, err error) {
 	cache.mut.Lock()
 	defer cache.mut.Unlock()
 	return cache.generic.Get(key)
 }
 
+// see caches.Interface for contract
+func (cache *guardedLRU) Range(f func(caches.Key, caches.Value) bool) {
+	cache.mut.Lock()
+	defer cache.mut.Unlock()
+	cache.generic.Range(f)
+}

--- a/src/types.go
+++ b/src/types.go
@@ -3,7 +3,7 @@ package caches
 type Key interface{}
 type Value interface{}
 
-type Interface interface{
+type Interface interface {
 	Keys() []Key
 
 	// Insert the given key/value pair into the cache returning the evicted value if any, else return nil.
@@ -11,4 +11,8 @@ type Interface interface{
 
 	// Retrieve the corrosponding value if present, else return `caches.MissingValueError`
 	Get(Key) (Value, error)
+
+	// Range will invoke the provided function for each key/value pair in the
+	// cache. Iteration stops if the function returns false.
+	Range(func(Key, Value) bool)
 }


### PR DESCRIPTION
## Summary
- extend cache interface with thread-safe Range method
- implement Range for LRU cache and hashicorp 2Q wrapper
- add Range to thread safe wrappers and generic template
- fix Keys method in hashicorp wrapper
- test Range functionality and wrappers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68882301357483308b828092cca83f96